### PR TITLE
NECO-172 enabled to delete user metadata.

### DIFF
--- a/lib/ricohapi/mstorage/client.rb
+++ b/lib/ricohapi/mstorage/client.rb
@@ -105,7 +105,7 @@ module RicohAPI
             token.delete endpoint_for("media/#{media_id}/meta/user/#{$1}")
           end
         else
-          raise Error.new("invalid key: #{key}")
+          raise Error.new("invalid key: #{key.inspect}")
         end
       end
 

--- a/lib/ricohapi/mstorage/client.rb
+++ b/lib/ricohapi/mstorage/client.rb
@@ -70,7 +70,7 @@ module RicohAPI
             token.get endpoint_for("media/#{media_id}/meta/user/#{$1}")
           end
         else
-          raise Error.new("invalid field_name: #{field_name}")
+          raise Error.new("invalid field_name: #{field_name.inspect}")
         end
       end
 

--- a/lib/ricohapi/mstorage/client.rb
+++ b/lib/ricohapi/mstorage/client.rb
@@ -95,7 +95,18 @@ module RicohAPI
 
       # DELETE /media/{id}/meta/user, DELETE /media/{id}/meta/user/{key}
       def remove_meta(media_id, key)
-        # TODO: do something
+        case key
+        when 'user'
+          handle_response(:as_raw) do
+            token.delete endpoint_for("media/#{media_id}/meta/user")
+          end
+        when USER_META_REGEX
+          handle_response(:as_raw) do
+            token.delete endpoint_for("media/#{media_id}/meta/user/#{$1}")
+          end
+        else
+          raise Error.new("invalid key: #{key}")
+        end
       end
 
       private

--- a/spec/ricohapi/mstorage/client_spec.rb
+++ b/spec/ricohapi/mstorage/client_spec.rb
@@ -128,4 +128,26 @@ describe RicohAPI::MStorage::Client do
       response.should == ''
     end
   end
+
+  describe '#remove_meta (all user metadata)' do
+    it 'should return nothing' do
+      response = mock_request :delete, "/media/#{media_id}/meta/user", 'delete.data' do
+        client.remove_meta media_id, 'user'
+      end
+      response.should == ''
+    end
+  end
+
+  describe '#remove_meta (specified user metadata)' do
+    it 'should return nothing' do
+      response = mock_request :delete, "/media/#{media_id}/meta/user/#{user_meta_key}", 'delete.data' do
+        client.remove_meta media_id, "user.#{user_meta_key}"
+      end
+      response.should == ''
+    end
+
+    it 'should raise error when key is invalid format' do
+      expect{client.remove_meta media_id, "user."}.to raise_error(RicohAPI::MStorage::Client::Error)
+    end
+  end
 end


### PR DESCRIPTION
## Ticket

[NECO-172](https://pflabo.atlassian.net/browse/NECO-172)
## Changes
- Implemented `remove_meta` method to enable to delete all/specified user metadata.
- Added corresponding tests.
## Tests
- Tested to success all rspec tests.
- Tested to delete all/specified user metadata.

Details are in [ticket](https://pflabo.atlassian.net/browse/NECO-172).
