### PR TITLE
NECO-197 fixed to refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ access_token = api_session.access_token
 ### Constructor
 
 ```ruby
+mstorage = RicohAPI::MStorage::Client.new access_token, {api_session: api_session}
+```
+
+or
+
+```ruby
 mstorage = RicohAPI::MStorage::Client.new access_token
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ access_token = api_session.access_token
 ### Constructor
 
 ```ruby
-mstorage = RicohAPI::MStorage::Client.new access_token, auth_client: client
+mstorage = RicohAPI::MStorage::Client.new client
 ```
 
 or

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ access_token = api_session.access_token
 ### Constructor
 
 ```ruby
-mstorage = RicohAPI::MStorage::Client.new access_token, {auth_client: client}
+mstorage = RicohAPI::MStorage::Client.new access_token, auth_client: client
 ```
 
 or

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ access_token = api_session.access_token
 ### Constructor
 
 ```ruby
-mstorage = RicohAPI::MStorage::Client.new access_token, {api_session: api_session}
+mstorage = RicohAPI::MStorage::Client.new access_token, {auth_client: client}
 ```
 
 or

--- a/lib/ricohapi/mstorage/client.rb
+++ b/lib/ricohapi/mstorage/client.rb
@@ -13,12 +13,12 @@ module RicohAPI
       MAX_USER_META_LENGTH = 1024
       MIN_USER_META_LENGTH = 1
 
-      def initialize(access_token, params = {})
-        if params[:auth_client]
-          self.auth_client = params[:auth_client]
-          self.token = self.auth_client.api_token_for! RicohAPI::MStorage::SCOPE
+      def initialize(token)
+        if token.is_a? Auth::Client
+          self.auth_client = token
+          self.token = self.auth_client.api_token_for!
         else
-          self.token = Auth::AccessToken.new access_token
+          self.token = Auth::AccessToken.new token
         end
       end
 
@@ -122,7 +122,7 @@ module RicohAPI
       private
 
       def handle_response(as_raw = false, retrying = false)
-        self.token = self.auth_client.api_token_for! RicohAPI::MStorage::SCOPE if self.auth_client
+        self.token = self.auth_client.api_token_for! if self.auth_client
 
         response = yield
         case response.status

--- a/lib/ricohapi/mstorage/client.rb
+++ b/lib/ricohapi/mstorage/client.rb
@@ -122,9 +122,7 @@ module RicohAPI
       private
 
       def handle_response(as_raw = false, retrying = false)
-        if self.auth_client
-          self.token = self.auth_client.api_token_for! RicohAPI::MStorage::SCOPE
-        end
+        self.token = self.auth_client.api_token_for! RicohAPI::MStorage::SCOPE if self.auth_client
 
         response = yield
         case response.status

--- a/lib/ricohapi/mstorage/client.rb
+++ b/lib/ricohapi/mstorage/client.rb
@@ -4,7 +4,7 @@
 module RicohAPI
   module MStorage
     class Client
-      attr_accessor :token, :api_session
+      attr_accessor :token, :auth_client
 
       class Error < StandardError; end
 
@@ -14,9 +14,9 @@ module RicohAPI
       MIN_USER_META_LENGTH = 1
 
       def initialize(access_token, params = {})
-        if params[:api_session]
-          self.api_session = params[:api_session]
-          self.token = params[:api_session].access_token
+        if params[:auth_client]
+          self.auth_client = params[:auth_client]
+          self.token = self.auth_client.api_token_for! RicohAPI::MStorage::SCOPE
         else
           self.token = Auth::AccessToken.new access_token
         end
@@ -125,9 +125,8 @@ module RicohAPI
       private
 
       def handle_response(as_raw = false, retrying = false)
-        if self.api_session && self.api_session.expired?
-          self.api_session = self.api_session.api_token_for! RicohAPI::MStorage::SCOPE
-          self.access_token = self.api_session.access_token
+        if self.auth_client
+          self.token = self.auth_client.api_token_for! RicohAPI::MStorage::SCOPE
         end
 
         response = yield


### PR DESCRIPTION
## Ticket

[NECO-197](https://pflabo.atlassian.net/browse/NECO-197)
## Changes
- Fixed to refresh token when token will soon expire.
## Tests
- Tested to refresh token automatically when initialize `RicohAPI::MStorage::Client` with `RicohAPI::Auth::Client` instance.

Details and test results are in [ticket](https://pflabo.atlassian.net/browse/NECO-197)
